### PR TITLE
Save manually selected timer to local var

### DIFF
--- a/firmware/SparkIntervalTimer.cpp
+++ b/firmware/SparkIntervalTimer.cpp
@@ -159,6 +159,7 @@ bool IntervalTimer::allocate_SIT(intPeriod Period, bool scale, TIMid id) {
 
 	if (id < NUM_SIT) {		// Allocate specified timer (id=TIMER3/4/5) or auto-allocate from pool (id=AUTO)
 		if (!SIT_used[id]) {
+			SIT_id = id;
 			start_SIT(Period, scale);
 			SIT_used[id] = true;
 			return true;


### PR DESCRIPTION
Need to save the manually allocated timer to the variable SID_id.  Otherwise the switch in start_SIT cannot setup the correct timer.
